### PR TITLE
1.5.5 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,58 +1,65 @@
-##1.0.0##
-+ Initial release
+##1.5.5##
+* Fixed sorting of certain items would cause a crash when there were filters for them ([6067](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/6067))
+* Fixed a possible crash when sorting cars or wagons with bigger inventories than any chest
 
-##1.0.1##
-* Fixed a bug causing items to be lost when inserted in the tick after sorting was triggered
+##1.5.4##
+* Fixed filtered car sorting ([5284](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/5284))
 
-##1.1.0##
-* Fixed a bug making it possible to duplicate items with durability in certain cases
-+ Added the auto-sort feature. It has performance problems to be solved though.
+##1.5.3##
+* Fixed temporary chests being selectable ([3947](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/3947))
 
-##1.1.1##
-* Fixed auto-sort performance, now sorting is done only when actually needed
+##1.5.2##
+* No more temporary entity spawning and destroying on every player inventory sort
+* Fixed filtered cargo-wagons weren't sorted properly
 
-##1.1.2##
-* Use of new API features of 0.13.12 to get rid of the need to place temporary entities
+##1.5.1##
+* Removed the left-over debugging message when auto-sorting
 
-##1.2.0##
-+ Addded an options menu
-+ Added part inventory sorting
-
-##1.3.0##
-* Changed the default shortcuts to use shift instead of ctrl (it's a lot more comfortable this way)
-+ Added chest sorting
-
-##1.4.0##
-* Fixed broken migration script (hopefully), apologies to anyone who had problems with this - it should be safe now to migrate from any version to 1.4
-+ Added sorting GUI
-
-##1.4.1##
-* Fixed a bug causing a crash when loading existing saves without the mod installed before ([1494](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/1494))
-
-##1.4.2##
-* Fixed logistic chests were not sortable ([1519](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/1519))
-
-##1.4.3##
-* Fixed sorting big chests caused a crash ([2008](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/2008))
-
-##1.4.4##
-* Updated for Factorio 0.14
+##1.5.0##
+* Internal changes
+* Improved auto-sort performance ([3558](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/3558))
 
 ##1.4.5##
 * Fixed GUI buttons would not appear when opened a logistic chest
 + Added car and wagon sorting
 + Added Russian translation thanks to [Apriori](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/3041)
 
-##1.5.0##
-* Internal changes
-* Improved auto-sort performance ([3558](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/3558))
+##1.4.4##
+* Updated for Factorio 0.14
 
-##1.5.1##
-* Removed the left-over debugging message when auto-sorting
+##1.4.3##
+* Fixed sorting big chests caused a crash ([2008](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/2008))
 
-##1.5.2##
-* No more temporary entity spawning and destroying on every player inventory sort
-* Fixed filtered cargo-wagons weren't sorted properly
+##1.4.2##
+* Fixed logistic chests were not sortable ([1519](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/1519))
 
-##1.5.3##
-* Fixed temporary chests being selectable ([3947](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/3947))
+##1.4.1##
+* Fixed a bug causing a crash when loading existing saves without the mod installed before ([1494](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/1494))
+
+##1.4.0##
+* Fixed broken migration script (hopefully), apologies to anyone who had problems with this - it should be safe now to migrate from any version to 1.4
++ Added sorting GUI
+
+##1.3.0##
+* Changed the default shortcuts to use shift instead of ctrl (it's a lot more comfortable this way)
++ Added chest sorting
+
+##1.2.0##
++ Addded an options menu
++ Added part inventory sorting
+
+##1.1.2##
+* Use of new API features of 0.13.12 to get rid of the need to place temporary entities
+
+##1.1.1##
+* Fixed auto-sort performance, now sorting is done only when actually needed
+
+##1.1.0##
+* Fixed a bug making it possible to duplicate items with durability in certain cases
++ Added the auto-sort feature. It has performance problems to be solved though.
+
+##1.0.1##
+* Fixed a bug causing items to be lost when inserted in the tick after sorting was triggered
+
+##1.0.0##
++ Initial release

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,11 +1,14 @@
 local size = 1000
 
-for i, v in pairs(data.raw["container"]) do
-	if v.inventory_size > size then size = v.inventory_size end
-end
+local data_to_check = {
+	data.raw["container"],
+	data.raw["logistic-container"],
+	data.raw["car"],
+	data.raw["cargo-wagon"]
+}
 
-for i, v in pairs(data.raw["logistic-container"]) do
-	if v.inventory_size > size then size = v.inventory_size end
+for _, t in pairs(data_to_check) do
+	for __, v in pairs(t) do if v.inventory_size > size then size = v.inventory_size; end; end
 end
 
 data.raw["container"]["manual-inventory-sort-tmp-chest"].inventory_size = size

--- a/info.json
+++ b/info.json
@@ -1,11 +1,11 @@
 {
 	"name": "manual-inventory-sort",
-	"version": "1.5.4",
+	"version": "1.5.5",
 	"factorio_version": "0.14",
 	"title": "Manual Inventory Sorting",
 	"author": "TheRustyKnife",
 	"description": "Makes some tweaks to the way inventory sorting works.\nYou can sort your inventory on demand or toggle auto-sort. Auto-sort can be configured to work for just a part of your inventory.\nIt's also possible to sort chests, cars and cargo wagons.",
 	"homepage": "http://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort",
-	"date": "07.11.2016",
+	"date": "10.12.2016",
 	"dependencies": ["base >= 0.14.4"]
 }

--- a/script/sorting.lua
+++ b/script/sorting.lua
@@ -13,7 +13,7 @@ local function iterate_i_slots(i_slots, inventory)
 		
 		if util.table.get_n(i_slots.filters[i_slots.current_name]) == 0 then -- get the next slot, if there are no other filtered ones (i_slot)
 			i_slots.filters[i_slots.current_name] = nil
-			i_slots.next = i_slots.i
+			i_slots.next = i_slots.i + 1
 		else -- get the next slot if there are other filtered ones (the first one)
 			i_slots.next = i_slots.filters[i_slots.current_name][1]
 		end
@@ -98,6 +98,16 @@ function sorting.sort_inventory(arg)
 	local filters = nil
 	local sort_limit = #inventory
 	
+	if (not sort_limit_override) and global.player_settings[player_index].sort_limit_enabled then
+		-- sort limit is enabled - need to figure out what it actually is
+		if global.player_settings[player_index].sort_limit >= 0 and global.player_settings[player_index].sort_limit < sort_limit then -- for positive limits (can't exceed inventory size)
+			sort_limit = global.player_settings[player_index].sort_limit
+			
+		elseif global.player_settings[player_index].sort_limit < 0 and global.player_settings[player_index].sort_limit > 0 - sort_limit then -- for negative limits (result can't be <= 0)
+			sort_limit = sort_limit + global.player_settings[player_index].sort_limit
+		end
+	end
+	
 	if filtered then -- figure out which slots have what filters
 		filters = {}
 		for i = 1, sort_limit do
@@ -107,16 +117,6 @@ function sorting.sort_inventory(arg)
 				if filters[filter] then table.insert(filters[filter], i)
 				else filters[filter] = {i} end
 			end
-		end
-	end
-	
-	if (not sort_limit_override) and global.player_settings[player_index].sort_limit_enabled then
-		-- sort limit is enabled - need to figure out what it actually is
-		if global.player_settings[player_index].sort_limit >= 0 and global.player_settings[player_index].sort_limit < sort_limit then -- for positive limits (can't exceed inventory size)
-			sort_limit = global.player_settings[player_index].sort_limit
-			
-		elseif global.player_settings[player_index].sort_limit < 0 and global.player_settings[player_index].sort_limit > 0 - sort_limit then -- for negative limits (result can't be <= 0)
-			sort_limit = sort_limit + global.player_settings[player_index].sort_limit
 		end
 	end
 	


### PR DESCRIPTION
* Fixed sorting of certain items would cause a crash when there were filters for them ([6067](https://mods.factorio.com/mods/theRustyKnife/manual-inventory-sort/discussion/6067))
* Fixed a possible crash when sorting cars or wagons with bigger inventories than any chest