### PR TITLE
Now partial sorting will skip first slots instead of last

### DIFF
--- a/manual-inventory-sort/locale/cs/locale.cfg
+++ b/manual-inventory-sort/locale/cs/locale.cfg
@@ -4,6 +4,7 @@ manual-inventory-auto-sort-on=Automatické třídění inventáře ZAPNUTO
 manual-inventory-gui-title=Nastavení řazení inventáře
 manual-inventory-gui-auto_sort=Zapnout automatické řazení inventáře
 manual-inventory-gui-sort_limit_enabled=Zapnout částečné řazení inventáře
+manual-inventory-gui-sort_limit_type=Vybrané sloty jsou tříděné
 manual-inventory-gui-sort_limit=Řadit pouze (počet slotů):
 manual-inventory-gui-sort_limit_override=Manuální řazení ignoruje limit
 manual-inventory-gui-custom_sort_enabled=Použít vlastní třízení

--- a/manual-inventory-sort/locale/en/locale.cfg
+++ b/manual-inventory-sort/locale/en/locale.cfg
@@ -4,6 +4,7 @@ manual-inventory-auto-sort-on=Automatic inventory sorting ON
 manual-inventory-gui-title=Inventory sorting settings
 manual-inventory-gui-auto_sort=Enable automatic inventory sorting
 manual-inventory-gui-sort_limit_enabled=Enable part inventory sorting
+manual-inventory-gui-sort_limit_type=Selected slots are sorted
 manual-inventory-gui-sort_limit=Sort only (slot count):
 manual-inventory-gui-sort_limit_override=Manual sorting ignores the limit
 manual-inventory-gui-custom_sort_enabled=Use custom sorting

--- a/manual-inventory-sort/script/gui.lua
+++ b/manual-inventory-sort/script/gui.lua
@@ -10,6 +10,7 @@ function gui.options_gui(player, settings)
 		
 		settings.auto_sort = gui["auto_sort"].state
 		settings.sort_limit_enabled = gui["sort_limit_enabled"].state
+		settings.sort_limit_type = gui["sort_limit_type"].state
 		settings.sort_limit = tonumber(gui["sort_limit_flow"]["sort_limit"].text)
 		settings.sort_limit_override = gui["flow_fix"]["sort_limit_override"].state
 		settings.sort_buttons_enabled = gui["flow_fix"]["sort_buttons_enabled"].state
@@ -24,6 +25,8 @@ function gui.options_gui(player, settings)
 		gui.add{type = "checkbox", name = "auto_sort", state = settings.auto_sort, caption = {"manual-inventory-gui-auto_sort"}}
 		
 		gui.add{type = "checkbox", name = "sort_limit_enabled", state = settings.sort_limit_enabled, caption = {"manual-inventory-gui-sort_limit_enabled"}}
+		
+		gui.add{type = "checkbox", name = "sort_limit_type", state = settings.sort_limit_type or false, caption = {"manual-inventory-gui-sort_limit_type"}}
 		
 		sort_limit_flow = gui.add{type = "flow", name = "sort_limit_flow"}
 		local t_gui = sort_limit_flow.add{type = "label", name = "sort_limit_caption", caption = {"manual-inventory-gui-sort_limit"}}

--- a/manual-inventory-sort/script/sorting.lua
+++ b/manual-inventory-sort/script/sorting.lua
@@ -97,19 +97,21 @@ function sorting.sort_inventory(arg)
 	local orders = {}
 	local filters = nil
 	local sort_limit = #inventory
-	local inventory_size = #inventory
+	local sort_start = 1
 	
 	if (not sort_limit_override) and global.player_settings[player_index].sort_limit_enabled then
 		-- sort limit is enabled - need to figure out what it actually is
+		-- sort limit now means "how many stacks not to sort" rather than the previous "how many stacks to sort"
+		-- supports sort_limit_type setting to allow the player to choose which mode she wnats to use
 		if global.player_settings[player_index].sort_limit >= 0 and global.player_settings[player_index].sort_limit < sort_limit then -- for positive limits (can't exceed inventory size)
-			sort_limit = global.player_settings[player_index].sort_limit
+			if global.player_settings[player_index].sort_limit_type then sort_limit = global.player_settings[player_index].sort_limit
+			else sort_start = global.player_settings[player_index].sort_limit+1; end
 			
 		elseif global.player_settings[player_index].sort_limit < 0 and global.player_settings[player_index].sort_limit > 0 - sort_limit then -- for negative limits (result can't be <= 0)
-			sort_limit = sort_limit + global.player_settings[player_index].sort_limit
+			if global.player_settings[player_index].sort_limit_type then sort_limit = sort_limit + global.player_settings[player_index].sort_limit
+			else sort_start = sort_limit + global.player_settings[player_index].sort_limit+1; end
 		end
 	end
-	local sort_start = inventory_size - sort_limit + 1 -- invert sort limit so don't first items
-	sort_limit = inventory_size
 	if filtered then -- figure out which slots have what filters
 		filters = {}
 		for i = sort_start, sort_limit do

--- a/manual-inventory-sort/script/sorting.lua
+++ b/manual-inventory-sort/script/sorting.lua
@@ -97,6 +97,7 @@ function sorting.sort_inventory(arg)
 	local orders = {}
 	local filters = nil
 	local sort_limit = #inventory
+	local inventory_size = #inventory
 	
 	if (not sort_limit_override) and global.player_settings[player_index].sort_limit_enabled then
 		-- sort limit is enabled - need to figure out what it actually is
@@ -107,10 +108,11 @@ function sorting.sort_inventory(arg)
 			sort_limit = sort_limit + global.player_settings[player_index].sort_limit
 		end
 	end
-	
+	local sort_start = inventory_size - sort_limit + 1 -- invert sort limit so don't first items
+	sort_limit = inventory_size
 	if filtered then -- figure out which slots have what filters
 		filters = {}
-		for i = 1, sort_limit do
+		for i = sort_start, sort_limit do
 			local filter = inventory.get_filter(i)
 			
 			if filter then
@@ -119,10 +121,9 @@ function sorting.sort_inventory(arg)
 			end
 		end
 	end
-	
 	------------ SORTING ------------
 	
-	for i = 1, sort_limit do -- put the content into a table
+	for i = sort_start, sort_limit do -- put the content into a table
 		local stack = inventory[i]
 		if stack ~= nil and stack.valid_for_read and stack.valid then
 			local prototype = game.item_prototypes[stack.name]
@@ -144,7 +145,7 @@ function sorting.sort_inventory(arg)
 	-- if global.player_settings[player_index].custom_sort_enabled then sort_orders(orders, global.player_settings[player_index].sorting_prefs) end -- WIP custom sorting (waiting for GUI)
 	
 	-- arrange the stacks in correct order into the t_chest inventory
-	local i_slots = {i = 0, current = 1, next = 2, filters = filters}
+	local i_slots = {i = sort_start - 1, current = sort_start, next = sort_start + 1, filters = filters}
 	for i = 1, #orders do -- go one order at a time, this also ensures that there's going to be only one item type in each iteration of this loop
 		local t_stacks = util.get_staks_with_order(orders[i], stacks)
 		local damaged_stacks = {} -- because stacks with damage go at the end
@@ -219,7 +220,7 @@ function sorting.sort_inventory(arg)
 	
 	------------ END OF SORTING ------------
 	
-	for i = 1, sort_limit do inventory[i].set_stack(t_chest_inventory[i]) end -- copy the sorted content back to the original inventory
+	for i = sort_start, sort_limit do inventory[i].set_stack(t_chest_inventory[i]) end -- copy the sorted content back to the original inventory
 	
 	if sorting_player then t_chest_inventory.clear() -- leave the t_chest in place with empty inventory if we were sorting players inventory
 	else t_chest.destroy() end -- destroy the chest otherwise


### PR DESCRIPTION
I find it much better to skip sorting of  a first line of inventory instead of a last because when I pick an item from there (click) and release (Q) it's returned to the same position (if there are no gaps gaps). With previous (last line) approach it would be returned to a first empty slot which is usually outside of "unsorted" area.

Please review the changes because I'm not sure about the line "local i_slots = {i = sort_start - 1, current = sort_start, next = sort_start + 1, filters = filters}"